### PR TITLE
Fix displaying methods/sub-classes of different(wrong) classes

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -34,7 +34,7 @@ module.exports =
             #Remove first element   
             firstElement = splitPrefix.shift()
             for command in allCommands
-                if firstCharsEqual(command.className, firstElement)
+                if command.className is firstElement
                     if command.childClasses.length is 0
                         # methods
                         suggestions = @getPossibleMethod(command.methods, splitPrefix.join('.'))


### PR DESCRIPTION
Issue: If the user typed f.e. 'turtle.' into the editor, the methods of the class 'term' would be suggested, because 'term' starts with the same character as 'turtle' and is earlier in the alphabet.

With this hotfix the correct suggestions will be displayed.