### PR TITLE
Fix to show suggestions of the word at the cursor position

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -73,7 +73,7 @@ module.exports =
     
     getPrefix: (editor, bufferPosition) ->
         # Whatever your prefix regex might be
-        regex = /([\w]+\.?)+\(?/
+        regex = /([\w]+\.?)+\(?$/
         line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
         line.match(regex)?[0] or ''
     


### PR DESCRIPTION
Issue: The suggestions are generated using the first word in the line. This is an issue if f.e. a while-loop is used, as the algorithm tries to use the word 'while' to generate suggestions.

This update to the regular expression makes sure to only return the last match.
As the string ends at the current cursor position, the word at the cursor position is used to generate the suggestions.